### PR TITLE
CODENVY-1905: add init process into master container

### DIFF
--- a/dockerfiles/redhat/Dockerfile
+++ b/dockerfiles/redhat/Dockerfile
@@ -19,7 +19,7 @@ ENV LANG=C.UTF-8 \
     DOCKER_BUCKET=get.docker.com \
     DOCKER_VERSION=1.6.0
 
-RUN apk add --update curl bash rsync sudo openssh postgresql-client postfix && \
+RUN apk add --update curl bash rsync sudo openssh postgresql-client postfix tini && \
     mkdir -p /opt/codenvy-data/ /opt/codenvy-data/logs /opt/codenvy-data/fs \
              /opt/codenvy-data/che-machines /opt/codenvy-data/che-machines-logs \
              /opt/codenvy-data/conf /opt/codenvy-data/conf/logback \
@@ -31,5 +31,6 @@ CMD [ "postfix", "-c", "/etc/postfix", "start" ]
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+# Use Tini as real entrypoint - init process that helps reaping zombies
+ENTRYPOINT ["/sbin/tini", "--", "/entrypoint.sh"]
 ADD codenvy-onpremises.tar.gz /opt/codenvy-tomcat


### PR DESCRIPTION
### What does this PR do?
Adds init process Tini into workspace master container. It prevents zombie emergence after killing rsync scripts because of timed out execution.

### What issues does this PR fix or reference?
Related to #1905.

### Changelog
Add init process to workspace master container to prevent zombie process appearance.